### PR TITLE
Fixes: branch w/ dot & url w/ .git at the end

### DIFF
--- a/src/git_url_destructor.rs
+++ b/src/git_url_destructor.rs
@@ -6,7 +6,7 @@ lazy_static! {
   static ref git_host: Regex = Regex::new(r"^(http(s)\:\/\/)?(www\.)?github\.com\/").unwrap();
 
   // Match any non slashes characters
-  static ref git_non_slash: Regex = Regex::new(r"([a-zA-Z0-9\-\_]+)").unwrap();
+  static ref git_non_slash: Regex = Regex::new(r"([a-zA-Z0-9\-\_\.]+)").unwrap();
 }
 
 pub struct GitUrlDestructor {

--- a/src/git_url_destructor.rs
+++ b/src/git_url_destructor.rs
@@ -7,6 +7,8 @@ lazy_static! {
 
   // Match any non slashes characters
   static ref git_non_slash: Regex = Regex::new(r"([a-zA-Z0-9\-\_\.]+)").unwrap();
+
+  static ref rm_dot_git_at_end: Regex = Regex::new(r"\.git$").unwrap();
 }
 
 pub struct GitUrlDestructor {
@@ -27,7 +29,9 @@ impl GitUrlDestructor {
   }
 
   pub fn exec_split(&mut self) {
-    let n_prot_host = git_host.replace(&self.url, "").to_string(); // No Protocol and host
+    let mut n_prot_host = git_host.replace(&self.url, "").to_string(); // No Protocol and host
+    n_prot_host = rm_dot_git_at_end.replace(&n_prot_host, "").to_string(); // Remove .git at the end
+
     let res: Vec<&str> = git_non_slash
       .find_iter(&n_prot_host)
       .map(|m| m.as_str())

--- a/src/r_patten_func.rs
+++ b/src/r_patten_func.rs
@@ -12,7 +12,7 @@ lazy_static! {
   pub static ref R_GITHUB_REPO_B: Regex =
     Regex::new(r"(github\.com)(\/[\w\-\_0-9]{1,39})").unwrap(); // Host with username
   pub static ref R_GITHUB_REPO_C: Regex =
-    Regex::new(r"(\/[a-zA-Z\-\_0-9]+){2,9}(\.git)?$").unwrap(); // Repository name w/o .git at the end
+    Regex::new(r"(\/[a-zA-Z\-\_0-9\.]+){2,20}(\.git)?$").unwrap(); // Repository name w/o .git at the end
 
   // Removing single and double qoutes from
   pub static ref R_REMOVE_QOUTES: Regex = Regex::new(r#"("|')"#).unwrap();
@@ -20,8 +20,8 @@ lazy_static! {
   // Check whether the token start with ghp and contains alpha numeric and 40 chars long
   pub static ref R_GIT_PAT: Regex = Regex::new(r"^(ghp_)[a-zA-Z0-9]{36}$").unwrap();
 
-  // Check if /tree/ exists in url
-  // pub static ref R_GIT_SUB_BRANCH: Regex = Regex::new(r"\.com\/([a-zA-Z\-\_0-9]+\/){2}tree\/").unwrap();
+  // Check if /tree/ exists in urls
+  // pub static ref R_GIT_SUB_BRANCH: Regex = Regex::new(r"\.com\/([a-zA-Z\-\_0-9]+\/\.){2}tree\/").unwrap();
 
   // Check if the string constains i dont know what to call
   pub static ref A_GIT_TAR_CONT: Regex = Regex::new(r"([a-zA-Z0-9\-\_]+)\-([a-zA-Z0-9\-\_]+)-([a-fA-F0-9]{7})\/$").unwrap();


### PR DESCRIPTION
Fix for issue #5 where branch with dot '.' in it fails due to regex missing '.'. 

Fix where url with ".git" at the end fails to recognize as valid url.
- Remove it through url destructor 